### PR TITLE
Add 'Skull Pot'.

### DIFF
--- a/Common/src/main/java/net/skeletoncrew/bonezone/Content.java
+++ b/Common/src/main/java/net/skeletoncrew/bonezone/Content.java
@@ -5,6 +5,7 @@ import net.darkhax.bookshelf.api.registry.RegistryDataProvider;
 import net.minecraft.world.item.Items;
 import net.skeletoncrew.bonezone.block.BoneCarverBlock;
 import net.skeletoncrew.bonezone.block.BoneLadderBlock;
+import net.skeletoncrew.bonezone.block.Skullpot;
 import net.skeletoncrew.bonezone.block.SpineSkullBlock;
 import net.skeletoncrew.bonezone.recipe.bonecarving.BonecarvingRecipeSerializer;
 import net.skeletoncrew.bonezone.ui.bonecarving.BonecarverMenu;
@@ -31,6 +32,11 @@ public class Content extends RegistryDataProvider {
         this.blocks.add(SpineSkullBlock::new, "spinal_skull_goat");
         this.blocks.add(SpineSkullBlock::new, "spinal_skull_deer");
         this.blocks.add(SpineSkullBlock::new, "spinal_skull_bird");
+        this.blocks.add(Skullpot::new, "skullpot_skeleton");
+        this.blocks.add(Skullpot::new, "skullpot_turned_skeleton");
+        this.blocks.add(Skullpot::new, "skullpot_creeper");
+        this.blocks.add(Skullpot::new, "skullpot_turned_creeper");
+
 
         // Items
         // TODO Only if we have non-block items

--- a/Common/src/main/java/net/skeletoncrew/bonezone/block/Skullpot.java
+++ b/Common/src/main/java/net/skeletoncrew/bonezone/block/Skullpot.java
@@ -1,0 +1,47 @@
+package net.skeletoncrew.bonezone.block;
+
+import net.darkhax.bookshelf.api.block.IBindRenderLayer;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.SoundType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.Material;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.VoxelShape;
+
+public class Skullpot extends Block implements IBindRenderLayer {
+    protected static final VoxelShape SHAPE = Block.box(4.0D, 0.0D, 4.0D, 12.0D, 8.0D, 12.0D);
+    private static final Properties PROPERTIES = Properties.of(Material.DECORATION)
+            .noOcclusion()
+            .strength(0.4f)
+            .sound(SoundType.BONE_BLOCK)
+            .isValidSpawn(Skullpot::never)
+            .isRedstoneConductor(Skullpot::never)
+            .isSuffocating(Skullpot::never)
+            .isViewBlocking(Skullpot::never);
+
+    public Skullpot() {
+        super(PROPERTIES);
+    }
+
+    private static boolean never(BlockState state, BlockGetter getter, BlockPos pos) {
+        return false;
+    }
+
+    private static boolean never(BlockState state, BlockGetter getter, BlockPos pos, EntityType<?> type) {
+        return false;
+    }
+
+    @Override
+    public RenderType getRenderLayerToBind() {
+        return RenderType.cutout();
+    }
+
+    public VoxelShape getShape(BlockState state, BlockGetter getter, BlockPos pos, CollisionContext collisionContext) {
+        return SHAPE;
+    }
+
+}

--- a/Common/src/main/resources/assets/bonezone/blockstates/skullpot_creeper.json
+++ b/Common/src/main/resources/assets/bonezone/blockstates/skullpot_creeper.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "bonezone:block/skullpot/creeper/regular"
+    }
+  }
+}

--- a/Common/src/main/resources/assets/bonezone/blockstates/skullpot_skeleton.json
+++ b/Common/src/main/resources/assets/bonezone/blockstates/skullpot_skeleton.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "bonezone:block/skullpot/skeleton/regular"
+    }
+  }
+}

--- a/Common/src/main/resources/assets/bonezone/blockstates/skullpot_turned_creeper.json
+++ b/Common/src/main/resources/assets/bonezone/blockstates/skullpot_turned_creeper.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "bonezone:block/skullpot/creeper/turned"
+    }
+  }
+}

--- a/Common/src/main/resources/assets/bonezone/blockstates/skullpot_turned_skeleton.json
+++ b/Common/src/main/resources/assets/bonezone/blockstates/skullpot_turned_skeleton.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "bonezone:block/skullpot/skeleton/turned"
+    }
+  }
+}

--- a/Common/src/main/resources/assets/bonezone/models/block/skullpot/creeper/regular.json
+++ b/Common/src/main/resources/assets/bonezone/models/block/skullpot/creeper/regular.json
@@ -1,0 +1,6 @@
+{
+  "parent": "bonezone:block/skullpot/regular",
+  "textures": {
+    "entity": "minecraft:entity/creeper/creeper"
+  }
+}

--- a/Common/src/main/resources/assets/bonezone/models/block/skullpot/creeper/turned.json
+++ b/Common/src/main/resources/assets/bonezone/models/block/skullpot/creeper/turned.json
@@ -1,0 +1,6 @@
+{
+  "parent": "bonezone:block/skullpot/turned",
+  "textures": {
+    "entity": "minecraft:entity/creeper/creeper"
+  }
+}

--- a/Common/src/main/resources/assets/bonezone/models/block/skullpot/regular.json
+++ b/Common/src/main/resources/assets/bonezone/models/block/skullpot/regular.json
@@ -1,0 +1,117 @@
+{
+  "textures": {
+    "skeleton": "minecraft:entity/skeleton/skeleton"
+  },
+  "elements": [
+    {
+      "from": [4, 0, 4],
+      "to": [12, 8, 12],
+      "rotation": {
+        "angle": 0,
+        "axis": "y",
+        "origin": [8, 4, 8]
+      },
+      "faces": {
+        "north": {
+          "uv": [2, 4, 4, 8],
+          "texture": "entity"
+        },
+        "east": {
+          "uv": [0, 4, 2, 8],
+          "texture": "entity"
+        },
+        "south": {
+          "uv": [6, 4, 8, 8],
+          "texture": "entity"
+        },
+        "west": {
+          "uv": [4, 4, 6, 8],
+          "texture": "entity"
+        },
+        "up": {
+          "uv": [4, 0, 6, 4],
+          "texture": "skeleton"
+        },
+        "down": {
+          "uv": [2, 0, 4, 4],
+          "texture": "entity"
+        }
+      }
+    },
+    {
+      "name": "cube_inside_inverse",
+      "from": [12, 1, 4],
+      "to": [4, 8, 12],
+      "rotation": {
+        "angle": 0,
+        "axis": "y",
+        "origin": [8, 4, 8]
+      },
+      "faces": {
+        "north": {
+          "uv": [2, 4.25, 4, 8],
+          "texture": "entity"
+        },
+        "east": {
+          "uv": [0, 4.25, 2, 8],
+          "texture": "entity"
+        },
+        "south": {
+          "uv": [6, 4.25, 8, 8],
+          "texture": "entity"
+        },
+        "west": {
+          "uv": [4, 4.25, 6, 8],
+          "texture": "entity"
+        },
+        "up": {
+          "uv": [4, 0, 6, 4],
+          "texture": "skeleton"
+        },
+        "down": {
+          "uv": [2, 0, 4, 4],
+          "texture": "entity"
+        }
+      }
+    }
+  ],
+  "display": {
+    "thirdperson_righthand": {
+      "rotation": [75, 45, 0],
+      "translation": [0, 2.5, 0],
+      "scale": [0.375, 0.375, 0.375]
+    },
+    "thirdperson_lefthand": {
+      "rotation": [75, 45, 0],
+      "translation": [0, 2.5, 0],
+      "scale": [0.375, 0.375, 0.375]
+    },
+    "firstperson_righthand": {
+      "rotation": [0, 45, 0],
+      "scale": [0.4, 0.4, 0.4]
+    },
+    "firstperson_lefthand": {
+      "rotation": [0, 225, 0],
+      "scale": [0.4, 0.4, 0.4]
+    },
+    "ground": {
+      "translation": [0, 3, 0],
+      "scale": [0.25, 0.25, 0.25]
+    },
+    "gui": {
+      "rotation": [30, 225, 0],
+      "scale": [0.625, 0.625, 0.625]
+    },
+    "fixed": {
+      "scale": [0.5, 0.5, 0.5]
+    }
+  },
+  "groups": [
+    {
+      "name": "group",
+      "origin": [0, 0, 0],
+      "color": 0,
+      "children": [0, 1]
+    }
+  ]
+}

--- a/Common/src/main/resources/assets/bonezone/models/block/skullpot/skeleton/regular.json
+++ b/Common/src/main/resources/assets/bonezone/models/block/skullpot/skeleton/regular.json
@@ -1,0 +1,6 @@
+{
+  "parent": "bonezone:block/skullpot/regular",
+  "textures": {
+    "entity": "minecraft:entity/skeleton/skeleton"
+  }
+}

--- a/Common/src/main/resources/assets/bonezone/models/block/skullpot/skeleton/turned.json
+++ b/Common/src/main/resources/assets/bonezone/models/block/skullpot/skeleton/turned.json
@@ -1,0 +1,6 @@
+{
+  "parent": "bonezone:block/skullpot/turned",
+  "textures": {
+    "entity": "minecraft:entity/skeleton/skeleton"
+  }
+}

--- a/Common/src/main/resources/assets/bonezone/models/block/skullpot/turned.json
+++ b/Common/src/main/resources/assets/bonezone/models/block/skullpot/turned.json
@@ -1,0 +1,129 @@
+{
+  "textures": {
+    "skeleton": "minecraft:entity/skeleton/skeleton"
+  },
+  "elements": [
+    {
+      "from": [4, 0, 4],
+      "to": [12, 8, 12],
+      "rotation": {
+        "angle": 0,
+        "axis": "y",
+        "origin": [8, 4, 8]
+      },
+      "faces": {
+        "north": {
+          "uv": [2, 4, 4, 8],
+          "rotation": 180,
+          "texture": "entity"
+        },
+        "east": {
+          "uv": [4, 4, 6, 8],
+          "rotation": 180,
+          "texture": "entity"
+        },
+        "south": {
+          "uv": [6, 4, 8, 8],
+          "rotation": 180,
+          "texture": "entity"
+        },
+        "west": {
+          "uv": [0, 4, 2, 8],
+          "rotation": 180,
+          "texture": "entity"
+        },
+        "up": {
+          "uv": [4, 0, 6, 4],
+          "rotation": 180,
+          "texture": "skeleton"
+        },
+        "down": {
+          "uv": [2, 0, 4, 4],
+          "rotation": 180,
+          "texture": "entity"
+        }
+      }
+    },
+    {
+      "name": "cube_inside_inverse",
+      "from": [12, 1, 4],
+      "to": [4, 8, 12],
+      "rotation": {
+        "angle": 0,
+        "axis": "y",
+        "origin": [8, 4, 8]
+      },
+      "faces": {
+        "north": {
+          "uv": [2, 4, 4, 8],
+          "rotation": 180,
+          "texture": "entity"
+        },
+        "east": {
+          "uv": [4, 4, 6, 8],
+          "rotation": 180,
+          "texture": "entity"
+        },
+        "south": {
+          "uv": [6, 4, 8, 8],
+          "rotation": 180,
+          "texture": "entity"
+        },
+        "west": {
+          "uv": [0, 4, 2, 8],
+          "rotation": 180,
+          "texture": "entity"
+        },
+        "up": {
+          "uv": [4, 0, 6, 4],
+          "rotation": 180,
+          "texture": "skeleton"
+        },
+        "down": {
+          "uv": [2, 0, 4, 4],
+          "rotation": 180,
+          "texture": "entity"
+        }
+      }
+    }
+  ],
+  "display": {
+    "thirdperson_righthand": {
+      "rotation": [75, 45, 0],
+      "translation": [0, 2.5, 0],
+      "scale": [0.375, 0.375, 0.375]
+    },
+    "thirdperson_lefthand": {
+      "rotation": [75, 45, 0],
+      "translation": [0, 2.5, 0],
+      "scale": [0.375, 0.375, 0.375]
+    },
+    "firstperson_righthand": {
+      "rotation": [0, 45, 0],
+      "scale": [0.4, 0.4, 0.4]
+    },
+    "firstperson_lefthand": {
+      "rotation": [0, 225, 0],
+      "scale": [0.4, 0.4, 0.4]
+    },
+    "ground": {
+      "translation": [0, 3, 0],
+      "scale": [0.25, 0.25, 0.25]
+    },
+    "gui": {
+      "rotation": [30, 225, 0],
+      "scale": [0.625, 0.625, 0.625]
+    },
+    "fixed": {
+      "scale": [0.5, 0.5, 0.5]
+    }
+  },
+  "groups": [
+    {
+      "name": "group",
+      "origin": [0, 0, 0],
+      "color": 0,
+      "children": [0, 1]
+    }
+  ]
+}

--- a/Common/src/main/resources/assets/bonezone/models/item/skullpot_creeper.json
+++ b/Common/src/main/resources/assets/bonezone/models/item/skullpot_creeper.json
@@ -1,0 +1,4 @@
+{
+  "parent": "bonezone:block/skullpot/creeper/regular"
+
+}

--- a/Common/src/main/resources/assets/bonezone/models/item/skullpot_skeleton.json
+++ b/Common/src/main/resources/assets/bonezone/models/item/skullpot_skeleton.json
@@ -1,0 +1,4 @@
+{
+  "parent": "bonezone:block/skullpot/skeleton/regular"
+
+}

--- a/Common/src/main/resources/assets/bonezone/models/item/skullpot_turned_creeper.json
+++ b/Common/src/main/resources/assets/bonezone/models/item/skullpot_turned_creeper.json
@@ -1,0 +1,3 @@
+{
+  "parent": "bonezone:block/skullpot/creeper/turned"
+}

--- a/Common/src/main/resources/assets/bonezone/models/item/skullpot_turned_skeleton.json
+++ b/Common/src/main/resources/assets/bonezone/models/item/skullpot_turned_skeleton.json
@@ -1,0 +1,3 @@
+{
+  "parent": "bonezone:block/skullpot/skeleton/turned",
+}


### PR DESCRIPTION
- Add two variants of Skull Pot : skeleton and creeper. 
- Add 'turned' variant.
- Skullpot currently only visual and none-functional.
- Skullpot has two base models that can be extended on:
     - for texture editing, use the 'entity' texture name
     - the top will always be the underside of a skeleton head, as it is hollow

Is the folder structure for the models alright/to liking? 
is the basic implementation correct?